### PR TITLE
Update documented domain to "net-ssh.github.io"

### DIFF
--- a/gateway/v1/api/files/README_rdoc.html
+++ b/gateway/v1/api/files/README_rdoc.html
@@ -72,7 +72,7 @@
       <h1><a href="../classes/Net/SSH/Gateway.html">Net::SSH::Gateway</a></h1>
 <ul>
 <li><a
-href="http://net-ssh.github.io/gateway">net-ssh.github.io/gateway</a>
+href="https://net-ssh.github.io/gateway">net-ssh.github.io/gateway</a>
 
 </li>
 </ul>

--- a/gateway/v1/api/files/README_rdoc.html
+++ b/gateway/v1/api/files/README_rdoc.html
@@ -72,7 +72,7 @@
       <h1><a href="../classes/Net/SSH/Gateway.html">Net::SSH::Gateway</a></h1>
 <ul>
 <li><a
-href="http://net-ssh.github.com/gateway">net-ssh.github.com/gateway</a>
+href="http://net-ssh.github.io/gateway">net-ssh.github.io/gateway</a>
 
 </li>
 </ul>

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     </p>
 
     <ul>
-      <li><a href="http://net-ssh.github.io/ssh/v1/index.html">Net::SSH version 1.x</a></li>
-      <li><a href="http://net-ssh.github.io/net-ssh/">Net::SSH version 2.x</a></li>
+      <li><a href="https://net-ssh.github.io/ssh/v1/index.html">Net::SSH version 1.x</a></li>
+      <li><a href="https://net-ssh.github.io/net-ssh/">Net::SSH version 2.x</a></li>
     </ul>
 
     <h1>Net::SFTP</h1>
@@ -25,8 +25,8 @@
     </p>
 
     <ul>
-      <li>Net::SFTP version 1.x <a href="http://net-ssh.github.io/sftp/v1/faq.html">FAQ</a> / <a href="http://net-ssh.github.io/sftp/v1/api/index.html">API</a></li>
-      <li><a href="http://net-ssh.github.io/sftp/v2/api/index.html">Net::SFTP version 2.x</a></li>
+      <li>Net::SFTP version 1.x <a href="https://net-ssh.github.io/sftp/v1/faq.html">FAQ</a> / <a href="https://net-ssh.github.io/sftp/v1/api/index.html">API</a></li>
+      <li><a href="https://net-ssh.github.io/sftp/v2/api/index.html">Net::SFTP version 2.x</a></li>
     </ul>
 
     <h1>Net::SCP</h1>
@@ -38,7 +38,7 @@
     </p>
 
     <ul>
-      <li><a href="http://net-ssh.github.io/scp/v1/api/index.html">Net::SCP version 1.x</a></li>
+      <li><a href="https://net-ssh.github.io/scp/v1/api/index.html">Net::SCP version 1.x</a></li>
     </ul>
 
     <h1>Net::SSH::Gateway</h1>
@@ -48,7 +48,7 @@
     </p>
 
     <ul>
-      <li><a href="http://net-ssh.github.io/gateway/v1/api/index.html">Net::SSH::Gateway version 1.x</a></li>
+      <li><a href="https://net-ssh.github.io/gateway/v1/api/index.html">Net::SSH::Gateway version 1.x</a></li>
     </ul>
 
     <h1>Net::SSH::Multi</h1>
@@ -59,7 +59,7 @@
     </p>
 
     <ul>
-      <li><a href="http://net-ssh.github.io/multi/v1/api/index.html">Net::SSH::Multi version 1.x</a></li>
+      <li><a href="https://net-ssh.github.io/multi/v1/api/index.html">Net::SSH::Multi version 1.x</a></li>
     </ul>
 
     <script type="text/javascript" src="http://include.reinvigorate.net/re_.js"></script>

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     </p>
 
     <ul>
-      <li><a href="http://net-ssh.github.com/ssh/v1/index.html">Net::SSH version 1.x</a></li>
-      <li><a href="http://net-ssh.github.com/net-ssh/">Net::SSH version 2.x</a></li>
+      <li><a href="http://net-ssh.github.io/ssh/v1/index.html">Net::SSH version 1.x</a></li>
+      <li><a href="http://net-ssh.github.io/net-ssh/">Net::SSH version 2.x</a></li>
     </ul>
 
     <h1>Net::SFTP</h1>
@@ -25,8 +25,8 @@
     </p>
 
     <ul>
-      <li>Net::SFTP version 1.x <a href="http://net-ssh.github.com/sftp/v1/faq.html">FAQ</a> / <a href="http://net-ssh.github.com/sftp/v1/api/index.html">API</a></li>
-      <li><a href="http://net-ssh.github.com/sftp/v2/api/index.html">Net::SFTP version 2.x</a></li>
+      <li>Net::SFTP version 1.x <a href="http://net-ssh.github.io/sftp/v1/faq.html">FAQ</a> / <a href="http://net-ssh.github.io/sftp/v1/api/index.html">API</a></li>
+      <li><a href="http://net-ssh.github.io/sftp/v2/api/index.html">Net::SFTP version 2.x</a></li>
     </ul>
 
     <h1>Net::SCP</h1>
@@ -38,7 +38,7 @@
     </p>
 
     <ul>
-      <li><a href="http://net-ssh.github.com/scp/v1/api/index.html">Net::SCP version 1.x</a></li>
+      <li><a href="http://net-ssh.github.io/scp/v1/api/index.html">Net::SCP version 1.x</a></li>
     </ul>
 
     <h1>Net::SSH::Gateway</h1>
@@ -48,7 +48,7 @@
     </p>
 
     <ul>
-      <li><a href="http://net-ssh.github.com/gateway/v1/api/index.html">Net::SSH::Gateway version 1.x</a></li>
+      <li><a href="http://net-ssh.github.io/gateway/v1/api/index.html">Net::SSH::Gateway version 1.x</a></li>
     </ul>
 
     <h1>Net::SSH::Multi</h1>
@@ -59,7 +59,7 @@
     </p>
 
     <ul>
-      <li><a href="http://net-ssh.github.com/multi/v1/api/index.html">Net::SSH::Multi version 1.x</a></li>
+      <li><a href="http://net-ssh.github.io/multi/v1/api/index.html">Net::SSH::Multi version 1.x</a></li>
     </ul>
 
     <script type="text/javascript" src="http://include.reinvigorate.net/re_.js"></script>

--- a/multi/v1/api/files/README_rdoc.html
+++ b/multi/v1/api/files/README_rdoc.html
@@ -72,7 +72,7 @@
       <h1><a href="../classes/Net/SSH/Multi.html">Net::SSH::Multi</a></h1>
 <ul>
 <li><a
-href="http://net-ssh.github.io/multi">net-ssh.github.io/multi</a>
+href="https://net-ssh.github.io/multi">net-ssh.github.io/multi</a>
 
 </li>
 </ul>

--- a/multi/v1/api/files/README_rdoc.html
+++ b/multi/v1/api/files/README_rdoc.html
@@ -72,7 +72,7 @@
       <h1><a href="../classes/Net/SSH/Multi.html">Net::SSH::Multi</a></h1>
 <ul>
 <li><a
-href="http://net-ssh.github.com/multi">net-ssh.github.com/multi</a>
+href="http://net-ssh.github.io/multi">net-ssh.github.io/multi</a>
 
 </li>
 </ul>

--- a/scp/v1/api/files/README_rdoc.html
+++ b/scp/v1/api/files/README_rdoc.html
@@ -71,7 +71,7 @@
     <div id="description">
       <h1><a href="../classes/Net/SCP.html">Net::SCP</a></h1>
 <ul>
-<li><a href="http://net-ssh.github.com/scp">net-ssh.github.com/scp</a>
+<li><a href="http://net-ssh.github.io/scp">net-ssh.github.io/scp</a>
 
 </li>
 </ul>

--- a/scp/v1/api/files/README_rdoc.html
+++ b/scp/v1/api/files/README_rdoc.html
@@ -71,7 +71,7 @@
     <div id="description">
       <h1><a href="../classes/Net/SCP.html">Net::SCP</a></h1>
 <ul>
-<li><a href="http://net-ssh.github.io/scp">net-ssh.github.io/scp</a>
+<li><a href="https://net-ssh.github.io/scp">net-ssh.github.io/scp</a>
 
 </li>
 </ul>

--- a/sftp/v2/api/files/README_rdoc.html
+++ b/sftp/v2/api/files/README_rdoc.html
@@ -71,7 +71,7 @@
     <div id="description">
       <h1><a href="../classes/Net/SFTP.html">Net::SFTP</a></h1>
 <ul>
-<li><a href="http://net-ssh.github.io/sftp">net-ssh.github.io/sftp</a>
+<li><a href="https://net-ssh.github.io/sftp">net-ssh.github.io/sftp</a>
 
 </li>
 </ul>

--- a/sftp/v2/api/files/README_rdoc.html
+++ b/sftp/v2/api/files/README_rdoc.html
@@ -71,7 +71,7 @@
     <div id="description">
       <h1><a href="../classes/Net/SFTP.html">Net::SFTP</a></h1>
 <ul>
-<li><a href="http://net-ssh.github.com/sftp">net-ssh.github.com/sftp</a>
+<li><a href="http://net-ssh.github.io/sftp">net-ssh.github.io/sftp</a>
 
 </li>
 </ul>

--- a/ssh/index.html
+++ b/ssh/index.html
@@ -5,7 +5,7 @@
   <body>
     <ul>
       <li><a href="./v1/">v1</a></li>
-      <li><a href="http://net-ssh.github.io/net-ssh/">v2</a></li>
+      <li><a href="https://net-ssh.github.io/net-ssh/">v2</a></li>
     </ul>
   </body>
 </html>

--- a/ssh/index.html
+++ b/ssh/index.html
@@ -5,7 +5,7 @@
   <body>
     <ul>
       <li><a href="./v1/">v1</a></li>
-      <li><a href="http://net-ssh.github.com/net-ssh/">v2</a></li>
+      <li><a href="http://net-ssh.github.io/net-ssh/">v2</a></li>
     </ul>
   </body>
 </html>

--- a/ssh/v1/chapter-1.html
+++ b/ssh/v1/chapter-1.html
@@ -170,7 +170,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
+            <li><a href="https://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-1.html
+++ b/ssh/v1/chapter-1.html
@@ -170,7 +170,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.com/api/index.html">Net::SSH API</a></li>
+            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-2.html
+++ b/ssh/v1/chapter-2.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.com/api/index.html">Net::SSH API</a></li>
+            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-2.html
+++ b/ssh/v1/chapter-2.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
+            <li><a href="https://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-3.html
+++ b/ssh/v1/chapter-3.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.com/api/index.html">Net::SSH API</a></li>
+            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-3.html
+++ b/ssh/v1/chapter-3.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
+            <li><a href="https://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-4.html
+++ b/ssh/v1/chapter-4.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.com/api/index.html">Net::SSH API</a></li>
+            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-4.html
+++ b/ssh/v1/chapter-4.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
+            <li><a href="https://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-5.html
+++ b/ssh/v1/chapter-5.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.com/api/index.html">Net::SSH API</a></li>
+            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-5.html
+++ b/ssh/v1/chapter-5.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
+            <li><a href="https://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-6.html
+++ b/ssh/v1/chapter-6.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.com/api/index.html">Net::SSH API</a></li>
+            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-6.html
+++ b/ssh/v1/chapter-6.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
+            <li><a href="https://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-7.html
+++ b/ssh/v1/chapter-7.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.com/api/index.html">Net::SSH API</a></li>
+            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-7.html
+++ b/ssh/v1/chapter-7.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
+            <li><a href="https://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 

--- a/ssh/v1/chapter-8.html
+++ b/ssh/v1/chapter-8.html
@@ -209,7 +209,7 @@
           <h2>API Reference</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.com/api">Net::SSH API</a></li>
+            <li><a href="http://net-ssh.github.io/api">Net::SSH API</a></li>
           </ul>
 
           
@@ -246,7 +246,7 @@
 
 	<h3>Location and Construction</h3>
 
-	<p>The Net::SSH transport layer is in the <a href="http://net-ssh.github.com/api/classes/Net/SSH/Transport.html">Net::SSH::Transport</a> module, and is composed of several classes. Some of the most significant components of the transport layer are:</p>
+	<p>The Net::SSH transport layer is in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport.html">Net::SSH::Transport</a> module, and is composed of several classes. Some of the most significant components of the transport layer are:</p>
 
 	<table class="list">
 		<tr>
@@ -255,17 +255,17 @@
 			<th>Description </th>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.com/api/classes/Net/SSH/Transport/Session.html">Session</a> </td>
+			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport/Session.html">Session</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/transport/session</code> </td>
 			<td> This represents a single session with a server. An instance of this object is the fundamental means by which all other pieces of the Net::SSH framework communicate with the remote server. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.com/api/classes/Net/SSH/Transport/WriterBuffer.html">WriterBuffer</a> </td>
+			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport/WriterBuffer.html">WriterBuffer</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/transport/buffer</code> </td>
 			<td> This is a class that makes it easier to encode data in <span class="caps">SSH</span>-specific formats. Various other layers of the Net::SSH framework employ the WriterBuffer class to help format packets to send to the server. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.com/api/classes/Net/SSH/Transport/ReaderBuffer.html">ReaderBuffer</a> </td>
+			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport/ReaderBuffer.html">ReaderBuffer</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/transport/buffer</code> </td>
 			<td> This is a class that makes it easier to decode data in <span class="caps">SSH</span>-specific formats. This is useful for taking apart packets received from the server. </td>
 		</tr>
@@ -277,7 +277,7 @@
 
 	<p>The connection to the server is either made using a <span class="caps">TCP</span>Socket, or if a proxy is given, the proxy is used to connect.</p>
 
-	<p>After connecting to the server, the transport session then instantiates an <a href="http://net-ssh.github.com/api/classes/Net/SSH/Transport/IncomingPacketStream.html">IncomingPacketStream</a> and an <a href="http://net-ssh.github.com/api/classes/Net/SSH/Transport/OutgoingPacketStream.html;">OutgoingPacketStream</a> these two classes are used to perform all <span class="caps">SSH</span>-mandated operations on packets as they are received or sent.</p>
+	<p>After connecting to the server, the transport session then instantiates an <a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport/IncomingPacketStream.html">IncomingPacketStream</a> and an <a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport/OutgoingPacketStream.html;">OutgoingPacketStream</a> these two classes are used to perform all <span class="caps">SSH</span>-mandated operations on packets as they are received or sent.</p>
 
 	<p>Once the packet streams are set up, version negoation takes place. Net::SSH reads the version of the server, and then tells the server what its own version is.</p>
 
@@ -309,7 +309,7 @@
 
 	<h3>Location and Construction</h3>
 
-	<p>The authentication layer exists in the <a href="http://net-ssh.github.com/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists (primarily) of three classes:</p>
+	<p>The authentication layer exists in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists (primarily) of three classes:</p>
 
 	<table class="list">
 		<tr>
@@ -318,17 +318,17 @@
 			<th>Description </th>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.com/api/classes/Net/SSH/Service/UserAuth.html">UserAuth</a> </td>
+			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/UserAuth.html">UserAuth</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/userauth</code> </td>
 			<td> The UserAuth class is the core of the authentication layer. It attempts each requested authentication method in turn, until one succeeds. To help, it uses the UserKeyManager class. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.com/api/classes/Net/SSH/Service/UserKeyManager.html">UserKeyManager</a> </td>
+			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/UserKeyManager.html">UserKeyManager</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/userkeys</code> </td>
 			<td> The UserKeyManager keeps track of all knows <em>identities</em> (public keys) of the current user. It abstracts the keys away from the rest of the application, so that other classes do not have to deal directly with the private keys. It also interacts with the <span class="caps">SSH</span> agent, if one is active, via the Agent class. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.com/api/classes/Net/SSH/Service/Agent.html">Agent</a> </td>
+			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/Agent.html">Agent</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/agent</code> </td>
 			<td> The Agent interfaces with the active <span class="caps">SSH</span> agent, if one is running. It provides an interface for querying all of the identities (public keys) that the agent knows of, and for performing operations with those identities. </td>
 		</tr>
@@ -358,7 +358,7 @@
 
 	<h3>Location and Construction</h3>
 
-	<p>The connection layer exists in the <a href="http://net-ssh.github.com/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists of only two classes:</p>
+	<p>The connection layer exists in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists of only two classes:</p>
 
 	<table class="list">
 		<tr>
@@ -367,12 +367,12 @@
 			<th>Description </th>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.com/api/classes/Net/SSH/Service/Connection.html">Connection</a> </td>
+			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/Connection.html">Connection</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/connection</code> </td>
 			<td> The Connection class manages the lifecycle of the channels. When the <code>main_loop</code> method is invoked, it is really the Connection&#8217;s <code>process_connection</code> method that does all the work. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.com/api/classes/Net/SSH/Service/Channel.html">Channel</a> </td>
+			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/Channel.html">Channel</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/channel</code> </td>
 			<td> The Channel class represents a single bidirectional communication channel across a connection. It provides a rich event-driven interface for handling the various events that occur in a channel. It also provides ways for sending data across a channel. </td>
 		</tr>
@@ -398,7 +398,7 @@
    
 
    <div class="section">
-     <p>The <em>session layer</em> is not a formal layer defined in the <span class="caps">SSH</span> specification. Instead, it is an abstraction provided by Net::SSH for accessing the connection layer. This layer is defined in the <a href="http://net-ssh.github.com/api/classes/Net/SSH/Session.html">Net::SSH::Session</a> class.</p>
+     <p>The <em>session layer</em> is not a formal layer defined in the <span class="caps">SSH</span> specification. Instead, it is an abstraction provided by Net::SSH for accessing the connection layer. This layer is defined in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/Session.html">Net::SSH::Session</a> class.</p>
 
 	<p>In truth, the Net::SSH::Session class is little more than a wrapper for the connection object, although it also instantiates the transport layer and invokes the authentication layer.<br />
 </p>
@@ -420,7 +420,7 @@
 
 	<h3>Location and Construction</h3>
 
-	<p>The port forwarding layer is, like all other services, defined in the <a href="http://net-ssh.github.com/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists of really only one significant class:</p>
+	<p>The port forwarding layer is, like all other services, defined in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists of really only one significant class:</p>
 
 	<table class="list">
 		<tr>
@@ -429,7 +429,7 @@
 			<th>Description </th>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.com/api/classes/Net/SSH/Service/PortForwardManager.html">PortForwardManager</a> </td>
+			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/PortForwardManager.html">PortForwardManager</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/forward</code> </td>
 			<td> The PortForwardManager manages all forwarded ports and connections. It uses a system of <em>handler objects</em> (each encapsulating a set of callbacks) to manage the operation of each forwarded connection. </td>
 		</tr>
@@ -455,7 +455,7 @@
 
 	<h3>Location and Construction</h3>
 
-	<p>The <span class="caps">SFTP</span> subsystem is defined in the <a href="http://net-ssh.github.com/api/classes/Net/SSH/SFTP.html">Net::SSH::SFTP</a> module, and consists of two primary classes:</p>
+	<p>The <span class="caps">SFTP</span> subsystem is defined in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/SFTP.html">Net::SSH::SFTP</a> module, and consists of two primary classes:</p>
 
 	<table class="list">
 		<tr>
@@ -464,12 +464,12 @@
 			<th>Description </th>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.com/api/classes/Net/SSH/SFTP/Session.html">Session</a> </td>
+			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/SFTP/Session.html">Session</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/sftp/session</code> </td>
 			<td> The Session class represents a single <span class="caps">SFTP</span> channel on a connection. All operations are asynchronous, which is inconvenient but powerful. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.com/api/classes/Net/SSH/SFTP/Simple.html">Simple</a> </td>
+			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/SFTP/Simple.html">Simple</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/sftp/simple</code> </td>
 			<td> The Simple class encapsulates both the Net::SSH::Session and Net::SSH::SFTP::Session. It also provides a <em>synchronous</em> interface, making it ideal for simple interactive <span class="caps">SFTP</span> sessions. </td>
 		</tr>

--- a/ssh/v1/chapter-8.html
+++ b/ssh/v1/chapter-8.html
@@ -209,7 +209,7 @@
           <h2>API Reference</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.io/api">Net::SSH API</a></li>
+            <li><a href="https://net-ssh.github.io/api">Net::SSH API</a></li>
           </ul>
 
           
@@ -246,7 +246,7 @@
 
 	<h3>Location and Construction</h3>
 
-	<p>The Net::SSH transport layer is in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport.html">Net::SSH::Transport</a> module, and is composed of several classes. Some of the most significant components of the transport layer are:</p>
+	<p>The Net::SSH transport layer is in the <a href="https://net-ssh.github.io/api/classes/Net/SSH/Transport.html">Net::SSH::Transport</a> module, and is composed of several classes. Some of the most significant components of the transport layer are:</p>
 
 	<table class="list">
 		<tr>
@@ -255,17 +255,17 @@
 			<th>Description </th>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport/Session.html">Session</a> </td>
+			<td style="vertical-align:top;"><a href="https://net-ssh.github.io/api/classes/Net/SSH/Transport/Session.html">Session</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/transport/session</code> </td>
 			<td> This represents a single session with a server. An instance of this object is the fundamental means by which all other pieces of the Net::SSH framework communicate with the remote server. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport/WriterBuffer.html">WriterBuffer</a> </td>
+			<td style="vertical-align:top;"><a href="https://net-ssh.github.io/api/classes/Net/SSH/Transport/WriterBuffer.html">WriterBuffer</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/transport/buffer</code> </td>
 			<td> This is a class that makes it easier to encode data in <span class="caps">SSH</span>-specific formats. Various other layers of the Net::SSH framework employ the WriterBuffer class to help format packets to send to the server. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport/ReaderBuffer.html">ReaderBuffer</a> </td>
+			<td style="vertical-align:top;"><a href="https://net-ssh.github.io/api/classes/Net/SSH/Transport/ReaderBuffer.html">ReaderBuffer</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/transport/buffer</code> </td>
 			<td> This is a class that makes it easier to decode data in <span class="caps">SSH</span>-specific formats. This is useful for taking apart packets received from the server. </td>
 		</tr>
@@ -277,7 +277,7 @@
 
 	<p>The connection to the server is either made using a <span class="caps">TCP</span>Socket, or if a proxy is given, the proxy is used to connect.</p>
 
-	<p>After connecting to the server, the transport session then instantiates an <a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport/IncomingPacketStream.html">IncomingPacketStream</a> and an <a href="http://net-ssh.github.io/api/classes/Net/SSH/Transport/OutgoingPacketStream.html;">OutgoingPacketStream</a> these two classes are used to perform all <span class="caps">SSH</span>-mandated operations on packets as they are received or sent.</p>
+	<p>After connecting to the server, the transport session then instantiates an <a href="https://net-ssh.github.io/api/classes/Net/SSH/Transport/IncomingPacketStream.html">IncomingPacketStream</a> and an <a href="https://net-ssh.github.io/api/classes/Net/SSH/Transport/OutgoingPacketStream.html;">OutgoingPacketStream</a> these two classes are used to perform all <span class="caps">SSH</span>-mandated operations on packets as they are received or sent.</p>
 
 	<p>Once the packet streams are set up, version negoation takes place. Net::SSH reads the version of the server, and then tells the server what its own version is.</p>
 
@@ -309,7 +309,7 @@
 
 	<h3>Location and Construction</h3>
 
-	<p>The authentication layer exists in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists (primarily) of three classes:</p>
+	<p>The authentication layer exists in the <a href="https://net-ssh.github.io/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists (primarily) of three classes:</p>
 
 	<table class="list">
 		<tr>
@@ -318,17 +318,17 @@
 			<th>Description </th>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/UserAuth.html">UserAuth</a> </td>
+			<td style="vertical-align:top;"><a href="https://net-ssh.github.io/api/classes/Net/SSH/Service/UserAuth.html">UserAuth</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/userauth</code> </td>
 			<td> The UserAuth class is the core of the authentication layer. It attempts each requested authentication method in turn, until one succeeds. To help, it uses the UserKeyManager class. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/UserKeyManager.html">UserKeyManager</a> </td>
+			<td style="vertical-align:top;"><a href="https://net-ssh.github.io/api/classes/Net/SSH/Service/UserKeyManager.html">UserKeyManager</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/userkeys</code> </td>
 			<td> The UserKeyManager keeps track of all knows <em>identities</em> (public keys) of the current user. It abstracts the keys away from the rest of the application, so that other classes do not have to deal directly with the private keys. It also interacts with the <span class="caps">SSH</span> agent, if one is active, via the Agent class. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/Agent.html">Agent</a> </td>
+			<td style="vertical-align:top;"><a href="https://net-ssh.github.io/api/classes/Net/SSH/Service/Agent.html">Agent</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/agent</code> </td>
 			<td> The Agent interfaces with the active <span class="caps">SSH</span> agent, if one is running. It provides an interface for querying all of the identities (public keys) that the agent knows of, and for performing operations with those identities. </td>
 		</tr>
@@ -358,7 +358,7 @@
 
 	<h3>Location and Construction</h3>
 
-	<p>The connection layer exists in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists of only two classes:</p>
+	<p>The connection layer exists in the <a href="https://net-ssh.github.io/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists of only two classes:</p>
 
 	<table class="list">
 		<tr>
@@ -367,12 +367,12 @@
 			<th>Description </th>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/Connection.html">Connection</a> </td>
+			<td style="vertical-align:top;"><a href="https://net-ssh.github.io/api/classes/Net/SSH/Service/Connection.html">Connection</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/connection</code> </td>
 			<td> The Connection class manages the lifecycle of the channels. When the <code>main_loop</code> method is invoked, it is really the Connection&#8217;s <code>process_connection</code> method that does all the work. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/Channel.html">Channel</a> </td>
+			<td style="vertical-align:top;"><a href="https://net-ssh.github.io/api/classes/Net/SSH/Service/Channel.html">Channel</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/channel</code> </td>
 			<td> The Channel class represents a single bidirectional communication channel across a connection. It provides a rich event-driven interface for handling the various events that occur in a channel. It also provides ways for sending data across a channel. </td>
 		</tr>
@@ -398,7 +398,7 @@
    
 
    <div class="section">
-     <p>The <em>session layer</em> is not a formal layer defined in the <span class="caps">SSH</span> specification. Instead, it is an abstraction provided by Net::SSH for accessing the connection layer. This layer is defined in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/Session.html">Net::SSH::Session</a> class.</p>
+     <p>The <em>session layer</em> is not a formal layer defined in the <span class="caps">SSH</span> specification. Instead, it is an abstraction provided by Net::SSH for accessing the connection layer. This layer is defined in the <a href="https://net-ssh.github.io/api/classes/Net/SSH/Session.html">Net::SSH::Session</a> class.</p>
 
 	<p>In truth, the Net::SSH::Session class is little more than a wrapper for the connection object, although it also instantiates the transport layer and invokes the authentication layer.<br />
 </p>
@@ -420,7 +420,7 @@
 
 	<h3>Location and Construction</h3>
 
-	<p>The port forwarding layer is, like all other services, defined in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists of really only one significant class:</p>
+	<p>The port forwarding layer is, like all other services, defined in the <a href="https://net-ssh.github.io/api/classes/Net/SSH/Service.html">Net::SSH::Service</a> module, and consists of really only one significant class:</p>
 
 	<table class="list">
 		<tr>
@@ -429,7 +429,7 @@
 			<th>Description </th>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/Service/PortForwardManager.html">PortForwardManager</a> </td>
+			<td style="vertical-align:top;"><a href="https://net-ssh.github.io/api/classes/Net/SSH/Service/PortForwardManager.html">PortForwardManager</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/service/forward</code> </td>
 			<td> The PortForwardManager manages all forwarded ports and connections. It uses a system of <em>handler objects</em> (each encapsulating a set of callbacks) to manage the operation of each forwarded connection. </td>
 		</tr>
@@ -455,7 +455,7 @@
 
 	<h3>Location and Construction</h3>
 
-	<p>The <span class="caps">SFTP</span> subsystem is defined in the <a href="http://net-ssh.github.io/api/classes/Net/SSH/SFTP.html">Net::SSH::SFTP</a> module, and consists of two primary classes:</p>
+	<p>The <span class="caps">SFTP</span> subsystem is defined in the <a href="https://net-ssh.github.io/api/classes/Net/SSH/SFTP.html">Net::SSH::SFTP</a> module, and consists of two primary classes:</p>
 
 	<table class="list">
 		<tr>
@@ -464,12 +464,12 @@
 			<th>Description </th>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/SFTP/Session.html">Session</a> </td>
+			<td style="vertical-align:top;"><a href="https://net-ssh.github.io/api/classes/Net/SSH/SFTP/Session.html">Session</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/sftp/session</code> </td>
 			<td> The Session class represents a single <span class="caps">SFTP</span> channel on a connection. All operations are asynchronous, which is inconvenient but powerful. </td>
 		</tr>
 		<tr>
-			<td style="vertical-align:top;"><a href="http://net-ssh.github.io/api/classes/Net/SSH/SFTP/Simple.html">Simple</a> </td>
+			<td style="vertical-align:top;"><a href="https://net-ssh.github.io/api/classes/Net/SSH/SFTP/Simple.html">Simple</a> </td>
 			<td style="vertical-align:top;"><code>net/ssh/sftp/simple</code> </td>
 			<td> The Simple class encapsulates both the Net::SSH::Session and Net::SSH::SFTP::Session. It also provides a <em>synchronous</em> interface, making it ideal for simple interactive <span class="caps">SFTP</span> sessions. </td>
 		</tr>

--- a/ssh/v1/chapter-9.html
+++ b/ssh/v1/chapter-9.html
@@ -209,7 +209,7 @@
           <h2>API Reference</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.com/api">Net::SSH API</a></li>
+            <li><a href="http://net-ssh.github.io/api">Net::SSH API</a></li>
           </ul>
 
           

--- a/ssh/v1/chapter-9.html
+++ b/ssh/v1/chapter-9.html
@@ -209,7 +209,7 @@
           <h2>API Reference</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.io/api">Net::SSH API</a></li>
+            <li><a href="https://net-ssh.github.io/api">Net::SSH API</a></li>
           </ul>
 
           

--- a/ssh/v1/index.html
+++ b/ssh/v1/index.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
+            <li><a href="https://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 
@@ -201,9 +201,9 @@
   
     Project Page: <a href="https://github.com/net-ssh/">https://github.com/net-ssh/</a><br />
   
-    User Manual: <a href="http://net-ssh.github.io">http://net-ssh.github.io</a><br />
+    User Manual: <a href="https://net-ssh.github.io">https://net-ssh.github.io</a><br />
   
-    API Documentation: <a href="http://net-ssh.github.io/api">http://net-ssh.github.io/api</a><br />
+    API Documentation: <a href="https://net-ssh.github.io/api">https://net-ssh.github.io/api</a><br />
   
 </p>
 

--- a/ssh/v1/index.html
+++ b/ssh/v1/index.html
@@ -169,7 +169,7 @@
           <h2>Other Documentation</h2>
 
           <ul>
-            <li><a href="http://net-ssh.github.com/api/index.html">Net::SSH API</a></li>
+            <li><a href="http://net-ssh.github.io/api/index.html">Net::SSH API</a></li>
             <li><a href="http://rubyforge.org/tracker/?atid=1842&group_id=274&func=browse">Net::SSH FAQ</a> (OUTDATED)</li>
           </ul>
 
@@ -201,9 +201,9 @@
   
     Project Page: <a href="https://github.com/net-ssh/">https://github.com/net-ssh/</a><br />
   
-    User Manual: <a href="http://net-ssh.github.com">http://net-ssh.github.com</a><br />
+    User Manual: <a href="http://net-ssh.github.io">http://net-ssh.github.io</a><br />
   
-    API Documentation: <a href="http://net-ssh.github.com/api">http://net-ssh.github.com/api</a><br />
+    API Documentation: <a href="http://net-ssh.github.io/api">http://net-ssh.github.io/api</a><br />
   
 </p>
 

--- a/ssh/v2/api/files/README_rdoc.html
+++ b/ssh/v2/api/files/README_rdoc.html
@@ -40,7 +40,7 @@
             <h1><a href="../classes/Net/SSH.html">Net::SSH</a></h1>
             <ul>
             <li>Docs: <a
-            href="http://net-ssh.github.com/net-ssh">net-ssh.github.com/net-ssh</a>
+            href="http://net-ssh.github.io/net-ssh">net-ssh.github.io/net-ssh</a>
             
             </li>
             <li>Issues: <a

--- a/ssh/v2/api/files/README_rdoc.html
+++ b/ssh/v2/api/files/README_rdoc.html
@@ -40,7 +40,7 @@
             <h1><a href="../classes/Net/SSH.html">Net::SSH</a></h1>
             <ul>
             <li>Docs: <a
-            href="http://net-ssh.github.io/net-ssh">net-ssh.github.io/net-ssh</a>
+            href="https://net-ssh.github.io/net-ssh">net-ssh.github.io/net-ssh</a>
             
             </li>
             <li>Issues: <a

--- a/ssh/v2/api/index.html
+++ b/ssh/v2/api/index.html
@@ -2,7 +2,7 @@
 <html lang='en' xml:lang='en' xmlns='http://www.w3.org/1999/xhtml'>
   <head>
     <title>Net::SSH: a pure-Ruby implementation of the SSH2 client protocol.</title>
-    <meta http-equiv="refresh" content="0;URL='http://net-ssh.github.com/net-ssh/'">
+    <meta http-equiv="refresh" content="0;URL='http://net-ssh.github.io/net-ssh/'">
     <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
   </head>
   <frameset border='1' bordercolor='gray' cols='20%, *' frameborder='1'>

--- a/ssh/v2/api/index.html
+++ b/ssh/v2/api/index.html
@@ -2,7 +2,7 @@
 <html lang='en' xml:lang='en' xmlns='http://www.w3.org/1999/xhtml'>
   <head>
     <title>Net::SSH: a pure-Ruby implementation of the SSH2 client protocol.</title>
-    <meta http-equiv="refresh" content="0;URL='http://net-ssh.github.io/net-ssh/'">
+    <meta http-equiv="refresh" content="0;URL='https://net-ssh.github.io/net-ssh/'">
     <meta content='text/html; charset=utf-8' http-equiv='Content-Type'>
   </head>
   <frameset border='1' bordercolor='gray' cols='20%, *' frameborder='1'>

--- a/ssh/v2/index.html
+++ b/ssh/v2/index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <meta http-equiv="refresh" content="0;URL='http://net-ssh.github.io/net-ssh/'">
+    <meta http-equiv="refresh" content="0;URL='https://net-ssh.github.io/net-ssh/'">
     <title>Net-SSH</title>
   </head>
   <body>

--- a/ssh/v2/index.html
+++ b/ssh/v2/index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <meta http-equiv="refresh" content="0;URL='http://net-ssh.github.com/net-ssh/'">
+    <meta http-equiv="refresh" content="0;URL='http://net-ssh.github.io/net-ssh/'">
     <title>Net-SSH</title>
   </head>
   <body>


### PR DESCRIPTION
## What

Fix #1

> Many (all?) links are pointing to github.com instead of github.io, which means they end up as 404's.

And... are you planning rename the repository?